### PR TITLE
Rename MigrationsBundle to MongoMigrationsBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@
 
 Dropwizard Mongo Migrations is a simple library to assist in migrating Mongo databases.  This library provides a set of 
 Dropwizard commands similar to Dropwizard's migration library for RDBS systems.
+
+The migrations are performed by the library [Mongock](https://www.mongock.io). This bundles sets up the configuration to 
+use the migration framework as a Dropwizard command.

--- a/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundle.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundle.java
@@ -4,7 +4,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 
-public abstract class MigrationsBundle <T extends Configuration> implements ConfiguredBundle<T>, MongoMigrationConfiguration<T> {
+public abstract class MongoMigrationsBundle<T extends Configuration> implements ConfiguredBundle<T>, MongoMigrationConfiguration<T> {
 
     private static final String DEFAULT_NAME = "db";
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.test.junit.jupiter.MongoServerExtension;
 
-class MigrationsBundleTest {
+class MongoMigrationsBundleTest {
     @RegisterExtension
     static final MongoServerExtension MONGO_SERVER_EXTENSION = new MongoServerExtension();
 
-    private final MigrationsBundle<TestMigrationConfiguration> migrationsBundle = new MigrationsBundle<>() {
+    private final MongoMigrationsBundle<TestMigrationConfiguration> migrationsBundle = new MongoMigrationsBundle<>() {
 
         @Override
         public String getMigrationPackage(TestMigrationConfiguration config) {


### PR DESCRIPTION
This is so it doesn't conflict with DW's MigrationBundle.

Update readme to reference Mongock.

Closes #4