### PR TITLE
Make the use of transactions configurable

### DIFF
--- a/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
@@ -30,7 +30,7 @@ public abstract class AbstractMongockCommand<T extends Configuration> extends Co
 
         var driver = MongoCore3Driver.withDefaultLock(mongoClient, migrationConfiguration.getDatabaseName(configuration));
 
-        if (migrationConfiguration.disableTransactions(configuration)) {
+        if (migrationConfiguration.shouldDisableTransactions(configuration)) {
             driver.disableTransaction();
         }
 

--- a/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
@@ -29,7 +29,10 @@ public abstract class AbstractMongockCommand<T extends Configuration> extends Co
         var mongoClient = MongoClients.create(migrationConfiguration.getMongoUri(configuration));
 
         var driver = MongoCore3Driver.withDefaultLock(mongoClient, migrationConfiguration.getDatabaseName(configuration));
-        driver.disableTransaction();
+
+        if (migrationConfiguration.disableTransactions(configuration)) {
+            driver.disableTransaction();
+        }
 
         var runner = MongockStandalone.builder()
                 .setDriver(driver)

--- a/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationConfiguration.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationConfiguration.java
@@ -5,7 +5,7 @@ public interface MongoMigrationConfiguration<T> {
     String getMongoUri(T config);
     String getDatabaseName(T config);
 
-    default boolean disableTransactions(T config) {
+    default boolean shouldDisableTransactions(T config) {
         return false;
     }
 }

--- a/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationConfiguration.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationConfiguration.java
@@ -4,4 +4,8 @@ public interface MongoMigrationConfiguration<T> {
     String getMigrationPackage(T config);
     String getMongoUri(T config);
     String getDatabaseName(T config);
+
+    default boolean disableTransactions(T config) {
+        return false;
+    }
 }

--- a/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
@@ -26,7 +26,7 @@ public class TestMongoMigrationConfiguration implements MongoMigrationConfigurat
     }
 
     @Override
-    public boolean disableTransactions(TestMigrationConfiguration config) {
+    public boolean shouldDisableTransactions(TestMigrationConfiguration config) {
         return true;
     }
 }

--- a/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
@@ -24,4 +24,9 @@ public class TestMongoMigrationConfiguration implements MongoMigrationConfigurat
     public String getDatabaseName(TestMigrationConfiguration config) {
         return databaseName;
     }
+
+    @Override
+    public boolean disableTransactions(TestMigrationConfiguration config) {
+        return true;
+    }
 }


### PR DESCRIPTION
There are instances where the MongoDb cluster does not support transactions, so there needs to be a way to disable transactions through configuration.

Closes #14