### PR TITLE
Bump spring from 5.3.9 to 5.3.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- Versions for provided dependencies -->
         <jakarta-el.version>3.0.4</jakarta-el.version>
-        <spring.version>5.3.9</spring.version>
+        <spring.version>5.3.13</spring.version>
 
         <!-- Versions for test dependencies -->
         <kiwi-test.version>1.1.1</kiwi-test.version>


### PR DESCRIPTION
Fixes CVE https://nvd.nist.gov/vuln/detail/CVE-2021-22096

Closes #13 