### PR TITLE
Begin work on migration to new Spring Data & Mongo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <!-- Versions for required dependencies -->
         <kiwi.version>1.3.1</kiwi.version>
-        <kiwi-bom.version>0.9.0</kiwi-bom.version>
+        <kiwi-bom.version>0.9.1</kiwi-bom.version>
 
         <!-- TODO: Should this be in the BOM?  It is only in this library currently -->
         <mongock.version>5.0.41</mongock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,20 +76,6 @@
             <version>${kiwi.version}</version>
         </dependency>
 
-        <!-- TODO Remove assuming we decide to drop support for Mongo 3.x driver (I think we should) -->
-        <!--
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-        </dependency>
-        -->
-
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.5.1</version>
-        </dependency>
-
         <dependency>
             <groupId>io.mongock</groupId>
             <artifactId>mongock-standalone</artifactId>
@@ -109,21 +95,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- TODO Does the following go away if we remove all the "discovery" code? -->
-        <!-- Comment/Uncomment the drivers below to ensure only the desired driver is being used in tests -->
-
-<!--        <dependency>-->
-<!--            <groupId>io.mongock</groupId>-->
-<!--            <artifactId>mongodb-v3-driver</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-
-        <dependency>
-            <groupId>io.mongock</groupId>
-            <artifactId>mongodb-sync-v4-driver</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>io.mongock</groupId>
             <artifactId>mongodb-springdata-v3-driver</artifactId>
@@ -134,6 +105,13 @@
                     <artifactId>spring-context</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- This is needed if the mongodb-springdata-v3-driver is being used -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>kiwi-parent</artifactId>
         <groupId>org.kiwiproject</groupId>
-        <version>1.8.2</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>dropwizard-mongo-migrations</artifactId>
@@ -29,7 +29,7 @@
     <properties>
         <!-- Versions for required dependencies -->
         <kiwi.version>1.3.1</kiwi.version>
-        <kiwi-bom.version>0.7.3</kiwi-bom.version>
+        <kiwi-bom.version>0.9.0</kiwi-bom.version>
 
         <!-- TODO: Should this be in the BOM?  It is only in this library currently -->
         <mongock.version>5.0.41</mongock.version>
@@ -110,7 +110,6 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -118,8 +117,6 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <!-- TODO: Also test with new version 3.3.4 -->
-            <version>3.3.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,18 @@
             <version>${kiwi.version}</version>
         </dependency>
 
+        <!-- TODO Remove assuming we decide to drop support for Mongo 3.x driver (I think we should) -->
+        <!--
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
+        </dependency>
+        -->
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.5.1</version>
         </dependency>
 
         <dependency>
@@ -100,6 +109,7 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- TODO Does the following go away if we remove all the "discovery" code? -->
         <!-- Comment/Uncomment the drivers below to ensure only the desired driver is being used in tests -->
 
 <!--        <dependency>-->
@@ -108,16 +118,15 @@
 <!--            <scope>test</scope>-->
 <!--        </dependency>-->
 
-<!--        <dependency>-->
-<!--            <groupId>io.mongock</groupId>-->
-<!--            <artifactId>mongodb-sync-v4-driver</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-
-        <!-- TODO: When kiwi updates to spring data v3 change this to use v3 driver -->
         <dependency>
             <groupId>io.mongock</groupId>
-            <artifactId>mongodb-springdata-v2-driver</artifactId>
+            <artifactId>mongodb-sync-v4-driver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.mongock</groupId>
+            <artifactId>mongodb-springdata-v3-driver</artifactId>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -127,11 +136,19 @@
             </exclusions>
         </dependency>
 
-        <!-- This is needed if the mongodb-springdata-v2-driver is being used -->
+        <!-- This is needed if the mongodb-springdata-v3-driver is being used -->
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
+            <!-- TODO: Also test with new version 3.3.4 -->
+            <version>3.3.3</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mongodb</groupId>
+                    <artifactId>mongodb-driver-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <groupId>io.mongock</groupId>
             <artifactId>mongodb-springdata-v3-driver</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,6 @@
             <groupId>io.mongock</groupId>
             <artifactId>mongodb-springdata-v3-driver</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -118,12 +112,6 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mongodb</groupId>
-                    <artifactId>mongodb-driver-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
@@ -49,8 +49,7 @@ public abstract class AbstractMongockCommand<T extends Configuration> extends Co
 
     // TODO: More of a question, do we want to allow through config to pass in an explicit driver classname instead of relying on auto discovery?
     private ConnectionDriver findDriver(MongoClient client, String databaseName) {
-        // TODO: When kiwi updates to spring data 3, then change this class to the v3 Spring data mongo driver
-        var springDataDriverClass = findDriverClass("io.mongock.driver.mongodb.springdata.v2.SpringDataMongoV2Driver");
+        var springDataDriverClass = findDriverClass("io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver");
 
         if (springDataDriverClass.isPresent()) {
             return createSpringDataDriver(springDataDriverClass.get(), client, databaseName);
@@ -59,6 +58,7 @@ public abstract class AbstractMongockCommand<T extends Configuration> extends Co
         var syncDriverClass = findDriverClass("io.mongock.driver.mongodb.v3.driver.MongoCore3Driver")
                 .or(() -> findDriverClass("io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver"))
                 .orElseThrow(() -> new IllegalStateException("Unable to find a valid Mongo driver for Mongock"));
+        // TODO Log (trace) the driver that was found?
 
         return createSyncDriver(syncDriverClass, client, databaseName);
     }

--- a/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
@@ -1,22 +1,12 @@
 package org.kiwiproject.migrations.mongo;
 
-import static org.kiwiproject.reflect.KiwiReflection.findMethod;
-import static org.kiwiproject.reflect.KiwiReflection.invokeExpectingReturn;
-
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
-import io.mongock.driver.api.driver.ConnectionDriver;
 import io.mongock.runner.core.executor.MongockRunner;
 import io.mongock.runner.standalone.MongockStandalone;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-import java.util.Optional;
-
-@Slf4j
 public abstract class AbstractMongockCommand<T extends Configuration> extends ConfiguredCommand<T> {
     private final Class<T> configurationClass;
     private final MongoMigrationConfiguration<T> migrationConfiguration;
@@ -34,9 +24,7 @@ public abstract class AbstractMongockCommand<T extends Configuration> extends Co
 
     @Override
     protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) {
-        var mongoClient = MongoClients.create(migrationConfiguration.getMongoUri(configuration));
-
-        var driver = findDriver(mongoClient, migrationConfiguration.getDatabaseName(configuration));
+        var driver = migrationConfiguration.getConnectionDriver(configuration);
         var runner = MongockStandalone.builder()
                 .setDriver(driver)
                 .addMigrationScanPackage(migrationConfiguration.getMigrationPackage(configuration))
@@ -47,49 +35,4 @@ public abstract class AbstractMongockCommand<T extends Configuration> extends Co
 
     protected abstract void run(Namespace namespace, MongockRunner mongock);
 
-    // TODO: More of a question, do we want to allow through config to pass in an explicit driver classname instead of relying on auto discovery?
-    private ConnectionDriver findDriver(MongoClient client, String databaseName) {
-        var springDataDriverClass = findDriverClass("io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver");
-
-        if (springDataDriverClass.isPresent()) {
-            return createSpringDataDriver(springDataDriverClass.get(), client, databaseName);
-        }
-
-        var syncDriverClass = findDriverClass("io.mongock.driver.mongodb.v3.driver.MongoCore3Driver")
-                .or(() -> findDriverClass("io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver"))
-                .orElseThrow(() -> new IllegalStateException("Unable to find a valid Mongo driver for Mongock"));
-        // TODO Log (trace) the driver that was found?
-
-        return createSyncDriver(syncDriverClass, client, databaseName);
-    }
-
-    private Optional<Class<?>> findDriverClass(String className) {
-        try {
-            var clazz = Class.forName(className);
-            LOG.info("Found Mongock driver {}", className);
-            return Optional.of(clazz);
-        } catch (ClassNotFoundException e) {
-            LOG.debug("Unable to find class {}", className, e);
-            return Optional.empty();
-        }
-    }
-
-    private ConnectionDriver createSyncDriver(Class<?> driverClass, MongoClient client, String databaseName) {
-        var creationMethod = findMethod(driverClass, "withDefaultLock", MongoClient.class, String.class);
-        return invokeExpectingReturn(creationMethod, null, ConnectionDriver.class, client, databaseName);
-    }
-
-    private ConnectionDriver createSpringDataDriver(Class<?> driverClass, MongoClient client, String databaseName) {
-        Class<?> mongoTemplateClass;
-        Object template;
-        try {
-            mongoTemplateClass = Class.forName("org.springframework.data.mongodb.core.MongoTemplate");
-            template = mongoTemplateClass.getDeclaredConstructor(MongoClient.class, String.class).newInstance(client, databaseName);
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to find or create MongoTemplate class which is required for the Spring Data Mongock drivers", e);
-        }
-
-        var creationMethod = findMethod(driverClass, "withDefaultLock", mongoTemplateClass);
-        return invokeExpectingReturn(creationMethod, null, ConnectionDriver.class, template);
-    }
 }

--- a/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationConfiguration.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationConfiguration.java
@@ -1,5 +1,7 @@
 package org.kiwiproject.migrations.mongo;
 
+import io.mongock.driver.api.driver.ConnectionDriver;
+
 public interface MongoMigrationConfiguration<T> {
 
     String DEFAULT_NAME = "db";
@@ -7,6 +9,7 @@ public interface MongoMigrationConfiguration<T> {
     String getMigrationPackage(T config);
     String getMongoUri(T config);
     String getDatabaseName(T config);
+    ConnectionDriver getConnectionDriver(T config);
 
     default boolean shouldDisableTransactions(T config) {
         return false;

--- a/src/test/java/org/kiwiproject/migrations/mongo/DbCommandTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/DbCommandTest.java
@@ -9,7 +9,6 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.ByteArrayOutputStream;
@@ -49,7 +48,6 @@ class DbCommandTest {
     }
 
     @Test
-    @EnabledIf("usesSpringData")
     void testRunSubCommandWithMongoTemplate() {
         var dbCommand = new DbCommand<>("db",
                 new TestMongoMigrationConfiguration(mongoConnectionString,
@@ -63,16 +61,6 @@ class DbCommandTest {
         var db = client.getDatabase(mongoDatabaseName);
 
         assertThat(db.getCollection("myTemplateCollection").countDocuments()).isEqualTo(1);
-    }
-
-    @SuppressWarnings("unused")
-    boolean usesSpringData() {
-        try {
-            var clazz = Class.forName("io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/migrations/mongo/DbCommandTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/DbCommandTest.java
@@ -3,8 +3,7 @@ package org.kiwiproject.migrations.mongo;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
+import com.mongodb.client.MongoClients;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.kiwiproject.test.junit.jupiter.MongoServerExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -21,6 +19,7 @@ import java.util.Map;
 
 class DbCommandTest {
 
+    // TODO This will NOT work until have the version from kiwi-test that uses the Mongo 4.x driver
     @RegisterExtension
     static final MongoServerExtension MONGO_SERVER_EXTENSION = new MongoServerExtension();
 
@@ -42,8 +41,7 @@ class DbCommandTest {
 
         dbCommand.run(null, new Namespace(Map.of("subcommand", "migrate")), new TestMigrationConfiguration());
 
-        var uri = new MongoClientURI(mongoConnectionString);
-        var client = new MongoClient(uri);
+        var client = MongoClients.create(mongoConnectionString);
 
         var db = client.getDatabase(mongoDatabaseName);
 
@@ -60,8 +58,7 @@ class DbCommandTest {
 
         dbCommand.run(null, new Namespace(Map.of("subcommand", "migrate")), new TestMigrationConfiguration());
 
-        var uri = new MongoClientURI(mongoConnectionString);
-        var client = new MongoClient(uri);
+        var client = MongoClients.create(mongoConnectionString);
 
         var db = client.getDatabase(mongoDatabaseName);
 
@@ -71,7 +68,7 @@ class DbCommandTest {
     @SuppressWarnings("unused")
     boolean usesSpringData() {
         try {
-            var clazz = Class.forName("io.mongock.driver.mongodb.springdata.v2.SpringDataMongoV2Driver");
+            var clazz = Class.forName("io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver");
             return true;
         } catch (ClassNotFoundException e) {
             return false;

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationConfigurationTest.java
@@ -3,6 +3,8 @@ package org.kiwiproject.migrations.mongo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
+import io.mongock.driver.api.driver.ConnectionDriver;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,11 @@ class MongoMigrationConfigurationTest {
 
             @Override
             public String getDatabaseName(Configuration config) {
+                return null;
+            }
+
+            @Override
+            public ConnectionDriver getConnectionDriver(Configuration config) {
                 return null;
             }
         };

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
@@ -2,11 +2,17 @@ package org.kiwiproject.migrations.mongo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.mongodb.client.MongoClients;
+
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.mongock.driver.api.driver.ConnectionDriver;
+import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
 class MongoMigrationsBundleTest {
 
@@ -29,6 +35,13 @@ class MongoMigrationsBundleTest {
         @Override
         public String getDatabaseName(TestMigrationConfiguration config) {
             return MONGO_SERVER_EXTENSION.getTestDatabaseName();
+        }
+
+        @Override
+        public ConnectionDriver getConnectionDriver(TestMigrationConfiguration config) {
+            var mongoClient = MongoClients.create(getMongoUri(config));
+            var mongoTemplate = new MongoTemplate(mongoClient, getDatabaseName(config));
+            return SpringDataMongoV3Driver.withDefaultLock(mongoTemplate);
         }
     };
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
@@ -7,9 +7,10 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.kiwiproject.test.junit.jupiter.MongoServerExtension;
 
 class MongoMigrationsBundleTest {
+
+    // TODO This will NOT work until have the version from kiwi-test that uses the Mongo 4.x driver
     @RegisterExtension
     static final MongoServerExtension MONGO_SERVER_EXTENSION = new MongoServerExtension();
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoServerExtension.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoServerExtension.java
@@ -1,0 +1,215 @@
+package org.kiwiproject.migrations.mongo;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.test.mongo.MongoServerTests.startInMemoryMongoServer;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import de.bwaldvogel.mongo.MongoServer;
+import de.bwaldvogel.mongo.ServerVersion;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.mongo.MongoServerTests;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+//
+// TODO THIS IS A TEMPORARY HACK UNTIL WE HAVE UPDATED kiwi-test TO THE NEW MONGO 4.X DRIVER.
+//  AFTER THAT, THIS ENTIRE CLASS NEEDS TO BE DELETED!!!!!
+//
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+/**
+ * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} that starts an in-memory
+ * {@link MongoServer} once before all tests have run, and which shuts it down once after all tests have run.
+ * An alternative for testing against "real" MongoDB instances is the {@link MongoDbExtension}.
+ * <p>
+ * By default, the in-memory test database will be dropped and re-created after each test so that each individual
+ * test can start with an empty database. If you need to retain the database between tests, construct an instance
+ * with the {@link DropTime#AFTER_ALL} option. The database will not be dropped or modified in any way before or
+ * after tests when this option is used. This is most useful in integration test scenarios in which tests are executed
+ * in a specific order and build upon the results of previous tests.
+ * <p>
+ * This extension also creates a test database with a unique name that can be used in tests, and provides accessors
+ * to enable tests to obtain various objects such as the connection string, the test database name, a
+ * {@link MongoDatabase} for the test database, a {@link MongoClient}, and more.
+ * <p>
+ * By default, the in-memory Mongo server will be set to the 3.6 flavor of Mongo.  If you need to use the 3.0 version of
+ * Mongo, then the {@link ServerVersion} can be passed into the constructor to set the version.
+ * <p>
+ * Usage:
+ * <pre>
+ * class MyMongoTest {
+ *
+ *    {@literal @}RegisterExtension
+ *     static final MongoServerExtension MONGO_SERVER_EXTENSION =
+ *             new MongoServerExtension();
+ *
+ *    {@literal @}Test
+ *     void testInsert() {
+ *         var database = MONGO_SERVER_EXTENSION.getTestDatabase();
+ *         database.createCollection("my_collection");
+ *         // ...
+ *     }
+ * }
+ * </pre>
+ *
+ * @see MongoDbExtension
+ */
+@Slf4j
+public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCallback {
+
+    private static final ServerVersion DEFAULT_SERVER_VERSION = ServerVersion.MONGO_3_6;
+
+    /**
+     * The in-memory {@link MongoServer} instance started by this extension.
+     */
+    @Getter
+    private MongoServer mongoServer;
+
+    /**
+     * Returns the Mongo connection string for the started {@link MongoServer}, e.g. {@code mongodb://localhost:34567}.
+     * It does <em>not</em> include the test database name, since this extension does not preclude creating other
+     * databases, for example a scenario in which the class under test integrates data from multiple MongoDB
+     * databases.
+     */
+    @Getter
+    private String connectionString;
+
+    /**
+     * The name of the test database created by this extension.
+     * <p>
+     * This is same across tests. Even though (by default using {@link DropTime#AFTER_EACH AFTER_EACH}) the test
+     * database is dropped after each test, a fresh database with the same name is immediately re-created following
+     * the drop.
+     */
+    @Getter
+    private String testDatabaseName;
+
+    /**
+     * The test {@link MongoDatabase} created by this extension.
+     * <p>
+     * When drop time is {@link DropTime#AFTER_EACH AFTER_EACH} (the default), a new instance is created after each
+     * test. Therefore tests should always re-initialize the database, for example in a {@code @BeforeEach} method.
+     */
+    @Getter
+    private MongoDatabase testDatabase;
+
+    /**
+     * A {@link MongoClient} that can be used in tests. This should never be closed by tests, as this client is
+     * opened before all tests, and closed after all tests have executed.
+     */
+    @Getter
+    private MongoClient mongoClient;
+
+    /**
+     * When to drop test databases.
+     */
+    @Getter
+    private final DropTime dropTime;
+
+    /**
+     * The version of the mongo server to use.
+     */
+    @Getter
+    private final ServerVersion serverVersion;
+
+    /**
+     * Creates a new instance that will drop and re-create the test database after each test.
+     * <p>
+     * The Mongo server will be set to the 3.6 version
+     */
+    public MongoServerExtension() {
+        this(DropTime.AFTER_EACH, DEFAULT_SERVER_VERSION);
+    }
+
+    /**
+     * Creates a new instance that will drop the test database using the given {@link DropTime}.
+     * <p>
+     * The Mongo server will be set to the 3.6 version
+     *
+     * @param dropTime when to drop the test database
+     */
+    public MongoServerExtension(DropTime dropTime) {
+        this(dropTime, DEFAULT_SERVER_VERSION);
+    }
+
+    /**
+     * Creates a new instance that will drop and re-create the test database after each test with the given {@link ServerVersion}.
+     *
+     * @param serverVersion the version of the mongo server to use.
+     */
+    public MongoServerExtension(ServerVersion serverVersion) {
+        this(DropTime.AFTER_EACH, serverVersion);
+    }
+
+    /**
+     * Creates a new instance that will drop the test database using the given {@link DropTime} and uses the given
+     * {@link ServerVersion}.
+     *
+     * @param dropTime when to drop the test database
+     * @param serverVersion the version of the mongo server to use
+     */
+    public MongoServerExtension(DropTime dropTime, ServerVersion serverVersion) {
+        this.dropTime = requireNotNull(dropTime, "dropTime cannot be null");
+        this.serverVersion = requireNotNull(serverVersion, "serverVersion cannot be null");
+    }
+
+    /**
+     * When to drop the test databases. The extension default is {@link DropTime#AFTER_EACH}, so that each test has
+     * a fresh database to test against. You can also drop the database after all tests have been run, which can be
+     * useful in certain integration test scenarios with ordered tests, for example when each test is a part of an
+     * overall workflow.
+     * <p>
+     * Note that because this extension uses an in-memory server, dropping and re-creating the test database after each
+     * test is no different than dropping before each test, so only the after each option is provided.
+     */
+    public enum DropTime {
+        AFTER_EACH, AFTER_ALL
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        mongoServer = startInMemoryMongoServer(serverVersion);
+        connectionString = MongoServerTests.getConnectionString(mongoServer);
+        testDatabaseName = generateTestDatabaseName();
+
+        mongoClient = MongoClients.create(connectionString);
+        testDatabase = mongoClient.getDatabase(testDatabaseName);
+    }
+
+    private static String generateTestDatabaseName() {
+        var millis = System.currentTimeMillis();
+        var random = ThreadLocalRandom.current().nextInt(10_000);
+        return f("test_db_{}_{}", millis, random);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (dropTime == DropTime.AFTER_EACH) {
+            dropAndRecreateTestDatabase();
+            LOG.trace("@AfterEach: Database {} was dropped and re-created", testDatabaseName);
+        }
+    }
+
+    private void dropAndRecreateTestDatabase() {
+        mongoClient.getDatabase(testDatabaseName).drop();
+        this.testDatabase = mongoClient.getDatabase(testDatabaseName);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        LOG.trace("@AfterAll: Closing Mongo client and shutting in-memory MongoServer down");
+        mongoClient.close();
+        mongoServer.shutdownNow();
+    }
+}

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoServerExtension.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoServerExtension.java
@@ -22,8 +22,10 @@ import java.util.concurrent.ThreadLocalRandom;
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //
-// TODO THIS IS A TEMPORARY HACK UNTIL WE HAVE UPDATED kiwi-test TO THE NEW MONGO 4.X DRIVER.
-//  AFTER THAT, THIS ENTIRE CLASS NEEDS TO BE DELETED AND USE THE ONE FROM kiwi-test 2.0.0
+// TODO Remove and replace with the eponymous extension from kiwi-test once 2.0.0 is released.
+//  This is a temporary hack until we have updated kiwi-test in 2.0.0 to work with the Mongo
+//  4.x driver. It has been copied directly from kiwi-test (after it was updated to work with
+//  the Mongo 4.x driver.)
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoServerExtension.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoServerExtension.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ThreadLocalRandom;
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //
 // TODO THIS IS A TEMPORARY HACK UNTIL WE HAVE UPDATED kiwi-test TO THE NEW MONGO 4.X DRIVER.
-//  AFTER THAT, THIS ENTIRE CLASS NEEDS TO BE DELETED!!!!!
+//  AFTER THAT, THIS ENTIRE CLASS NEEDS TO BE DELETED AND USE THE ONE FROM kiwi-test 2.0.0
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -66,7 +66,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * @see MongoDbExtension
  */
 @Slf4j
-public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCallback {
+class MongoServerExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCallback {
 
     private static final ServerVersion DEFAULT_SERVER_VERSION = ServerVersion.MONGO_3_6;
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
@@ -1,5 +1,12 @@
 package org.kiwiproject.migrations.mongo;
 
+import com.mongodb.client.MongoClients;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import io.mongock.driver.api.driver.ConnectionDriver;
+import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
+
 public class TestMongoMigrationConfiguration implements MongoMigrationConfiguration<TestMigrationConfiguration> {
 
     private final String mongoUri;
@@ -30,5 +37,12 @@ public class TestMongoMigrationConfiguration implements MongoMigrationConfigurat
     @Override
     public boolean shouldDisableTransactions(TestMigrationConfiguration config) {
         return true;
+    }
+
+    @Override
+    public ConnectionDriver getConnectionDriver(TestMigrationConfiguration config) {
+        var mongoClient = MongoClients.create(mongoUri);
+        var mongoTemplate = new MongoTemplate(mongoClient, databaseName);
+        return SpringDataMongoV3Driver.withDefaultLock(mongoTemplate);
     }
 }


### PR DESCRIPTION
Initial work to transition to Spring Data MongoDB 3.x and Mongo 4.x
driver. There are a lot of TODOs, and in order for the tests to work,
I had to copy the MongoServerExtension from kiwi-test and modify
it to work with the Mongo 4.x driver.

We also discussed removing support for Mongo 3.x driver and
removing the "automatic discovery" code and instead requiring
users (i.e. us) to pass in the ConnectionDriver explicitly.

Closes #60 