### PR TITLE
Remove TODOs that are OBE

### DIFF
--- a/src/test/java/org/kiwiproject/migrations/mongo/DbCommandTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/DbCommandTest.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 class DbCommandTest {
 
-    // TODO This will NOT work until have the version from kiwi-test that uses the Mongo 4.x driver
     @RegisterExtension
     static final MongoServerExtension MONGO_SERVER_EXTENSION = new MongoServerExtension();
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
@@ -16,7 +16,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 
 class MongoMigrationsBundleTest {
 
-    // TODO This will NOT work until have the version from kiwi-test that uses the Mongo 4.x driver
     @RegisterExtension
     static final MongoServerExtension MONGO_SERVER_EXTENSION = new MongoServerExtension();
 


### PR DESCRIPTION
A few TODOs were accidentally left in several tests. They will be resolved as soon as kiwi-test 2.0.0 is released and we change to use its updated MongoServerExtension.