### PR TITLE
Skip PR workflows if only md/txt files changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Don't run the build on pull requests if only Markdown or text files have changed.