### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -61,16 +61,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <artifactId>kiwi-parent</artifactId>
         <groupId>org.kiwiproject</groupId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dropwizard-mongo-migrations</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
@@ -28,14 +28,14 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
 
         <!-- TODO: Should this be in the BOM?  It is only in this library currently -->
         <mongock.version>5.3.3</mongock.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-mongo-migrations</sonar.projectKey>
@@ -112,14 +112,8 @@
 
         <dependency>
             <groupId>io.mongock</groupId>
-            <artifactId>mongodb-springdata-v3-driver</artifactId>
+            <artifactId>mongodb-springdata-v4-driver</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/AbstractMongockCommand.java
@@ -4,9 +4,9 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.cli.ConfiguredCommand;
-import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.cli.ConfiguredCommand;
+import io.dropwizard.core.setup.Bootstrap;
 import io.mongock.runner.core.executor.MongockRunner;
 import io.mongock.runner.standalone.MongockStandalone;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/kiwiproject/migrations/mongo/DbCommand.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/DbCommand.java
@@ -2,7 +2,7 @@ package org.kiwiproject.migrations.mongo;
 
 import static java.util.Objects.requireNonNull;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.mongock.runner.core.executor.MongockRunner;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;

--- a/src/main/java/org/kiwiproject/migrations/mongo/DbMigrateCommand.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/DbMigrateCommand.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.migrations.mongo;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.mongock.runner.core.executor.MongockRunner;
 import net.sourceforge.argparse4j.inf.Namespace;
 

--- a/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundle.java
+++ b/src/main/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundle.java
@@ -1,8 +1,8 @@
 package org.kiwiproject.migrations.mongo;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.ConfiguredBundle;
+import io.dropwizard.core.setup.Bootstrap;
 
 public abstract class MongoMigrationsBundle<T extends Configuration> implements ConfiguredBundle<T>, MongoMigrationConfiguration<T> {
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/AbstractMongockCommandTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/AbstractMongockCommandTest.java
@@ -3,16 +3,15 @@ package org.kiwiproject.migrations.mongo;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 
+import io.dropwizard.core.setup.Bootstrap;
+import io.mongock.driver.api.driver.ConnectionDriver;
+import io.mongock.runner.core.executor.MongockRunner;
+import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.kiwiproject.test.junit.jupiter.params.provider.AsciiOnlyBlankStringSource;
-
-import io.dropwizard.setup.Bootstrap;
-import io.mongock.driver.api.driver.ConnectionDriver;
-import io.mongock.runner.core.executor.MongockRunner;
-import net.sourceforge.argparse4j.inf.Namespace;
 
 class AbstractMongockCommandTest {
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationConfigurationTest.java
@@ -2,9 +2,8 @@ package org.kiwiproject.migrations.mongo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.mongock.driver.api.driver.ConnectionDriver;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/MongoMigrationsBundleTest.java
@@ -3,13 +3,11 @@ package org.kiwiproject.migrations.mongo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mongodb.client.MongoClients;
-
-import io.dropwizard.Application;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 import io.mongock.driver.api.driver.ConnectionDriver;
-import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
-
+import io.mongock.driver.mongodb.springdata.v4.SpringDataMongoV4Driver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.test.junit.jupiter.MongoServerExtension;
@@ -41,7 +39,7 @@ class MongoMigrationsBundleTest {
         public ConnectionDriver getConnectionDriver(TestMigrationConfiguration config) {
             var mongoClient = MongoClients.create(getMongoUri(config));
             var mongoTemplate = new MongoTemplate(mongoClient, getDatabaseName(config));
-            return SpringDataMongoV3Driver.withDefaultLock(mongoTemplate);
+            return SpringDataMongoV4Driver.withDefaultLock(mongoTemplate);
         }
     };
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/TestMigrationConfiguration.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/TestMigrationConfiguration.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.migrations.mongo;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
+++ b/src/test/java/org/kiwiproject/migrations/mongo/TestMongoMigrationConfiguration.java
@@ -1,11 +1,9 @@
 package org.kiwiproject.migrations.mongo;
 
 import com.mongodb.client.MongoClients;
-
-import org.springframework.data.mongodb.core.MongoTemplate;
-
 import io.mongock.driver.api.driver.ConnectionDriver;
-import io.mongock.driver.mongodb.springdata.v3.SpringDataMongoV3Driver;
+import io.mongock.driver.mongodb.springdata.v4.SpringDataMongoV4Driver;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
 public class TestMongoMigrationConfiguration implements MongoMigrationConfiguration<TestMigrationConfiguration> {
 
@@ -43,6 +41,6 @@ public class TestMongoMigrationConfiguration implements MongoMigrationConfigurat
     public ConnectionDriver getConnectionDriver(TestMigrationConfiguration config) {
         var mongoClient = MongoClients.create(mongoUri);
         var mongoTemplate = new MongoTemplate(mongoClient, databaseName);
-        return SpringDataMongoV3Driver.withDefaultLock(mongoTemplate);
+        return SpringDataMongoV4Driver.withDefaultLock(mongoTemplate);
     }
 }


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9