### PR TITLE
chore: remove Embedded Mongo cache step from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Cache Embedded Mongo files
-        uses: actions/cache@v5
-        with:
-          path: ~/.embedmongo
-          key: ${{ runner.os }}-embedmongo
-          restore-keys: ${{ runner.os }}-embedmongo
-
       # Compile the project
       - name: Build
         env:


### PR DESCRIPTION
The project no longer uses Embedded Mongo, so the cache step for
~/.embedmongo is obsolete and was producing a path validation warning
in CI.