### PR TITLE
Bump kiwi-parent from 3.0.39 to 3.0.40 and fix parent element order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>kiwi-parent</artifactId>
         <groupId>org.kiwiproject</groupId>
-        <version>3.0.39</version>
+        <version>3.0.40</version>
     </parent>
 
     <artifactId>dropwizard-mongo-migrations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>kiwi-parent</artifactId>
         <groupId>org.kiwiproject</groupId>
+        <artifactId>kiwi-parent</artifactId>
         <version>3.0.40</version>
     </parent>
 


### PR DESCRIPTION
Bump kiwi-parent from 3.0.39 to 3.0.40. Also fix the groupId/artifactId order in the parent block to match the standard convention used in all other repos.